### PR TITLE
k6 Performance Test for Adding Value

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ffc-grants-addvalue-web",
-  "version": "2.38.11",
+  "version": "2.38.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ffc-grants-addvalue-web",
-      "version": "2.38.11",
+      "version": "2.38.14",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@defra/hapi-gapi": "^2.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-grants-addvalue-web",
-  "version": "2.38.13",
+  "version": "2.38.14",
   "description": "Web frontend for FTF adding value scheme",
   "homepage": "https://github.com/DEFRA/ffc-grants-addvalue-web",
   "main": "app/index.js",

--- a/test/performance/.dockerignore
+++ b/test/performance/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+.dockerignore
+docker-compose*
+Dockerfile
+README.md

--- a/test/performance/Dockerfile
+++ b/test/performance/Dockerfile
@@ -1,0 +1,3 @@
+FROM grafana/k6
+COPY script.js /script.js
+CMD ["run", "/script.js"]

--- a/test/performance/Dockerfile
+++ b/test/performance/Dockerfile
@@ -1,3 +1,4 @@
 FROM grafana/k6
 COPY script.js /script.js
+USER k6
 CMD ["run", "/script.js"]

--- a/test/performance/README.md
+++ b/test/performance/README.md
@@ -1,16 +1,17 @@
 # Performance Tests
-This folder contains the performance tests for the Adding Value Grant web app. The framework used is Grafana k6.
+This folder contains the single performance test for the Adding Value Grant web app. The framework used is Grafana k6.
 
-## Set-up
+## Set up
 k6 can be installed and run locally on the machine, or a docker container with k6 is available. See https://grafana.com/docs/k6/latest/set-up/install-k6/.
 
-k6 does not use NodeJS but _npm install_ can be used to install the _@types/k6_ package to give VS Code Intellisense.
+k6 does not use NodeJS but _npm install_ can be used to install the _@types/k6_ package to give intellisense in VS Code.
 
-## Running k6 in a container
-From the `/test/performance` directory run `docker-compose run --build --rm perf-test`. This will run the single performance test defined in script.js.
-
-## Running k6 on a local machine
+## Running the test in a container
 ```pwsh
-# change root url as needed
+docker-compose run --build --rm perf-test
+```
+
+## Running the tests against a local k6 installation
+```pwsh
 k6 run -e TEST_ENVIRONMENT_ROOT_URL=https://ffc-grants-frontend-test.azure.defra.cloud script.js
 ```

--- a/test/performance/README.md
+++ b/test/performance/README.md
@@ -1,15 +1,15 @@
 # Performance Tests
 This folder contains the performance tests for the Adding Value Grant web app. The framework used is Grafana k6.
 
-## Set up
-k6 can be installed and run locally on the machine, or a docker container with k6 is available. See https://grafana.com/docs/k6/latest/set-up/install-k6/
+## Set-up
+k6 can be installed and run locally on the machine, or a docker container with k6 is available. See https://grafana.com/docs/k6/latest/set-up/install-k6/.
 
 k6 does not use NodeJS but _npm install_ can be used to install the _@types/k6_ package to give VS Code Intellisense.
 
 ## Running k6 in a container
-Todo..
+From the `/test/performance` directory run `docker-compose run --build --rm perf-test`. This will run the single performance test defined in script.js.
 
-## Running k6 on the machine
+## Running k6 on a local machine
 ```pwsh
 # change root url as needed
 k6 run -e TEST_ENVIRONMENT_ROOT_URL=https://ffc-grants-frontend-test.azure.defra.cloud script.js

--- a/test/performance/README.md
+++ b/test/performance/README.md
@@ -1,0 +1,12 @@
+# Performance Tests
+This folder contains the performance tests for the Adding Value Grant web app. The framework used is Grafana k6.
+
+## Requirements
+- Docker
+- npm
+- k6 (if running outside a container)
+
+## Running tests outside a container
+```pwsh
+k6 run script.js
+```

--- a/test/performance/README.md
+++ b/test/performance/README.md
@@ -1,12 +1,16 @@
 # Performance Tests
 This folder contains the performance tests for the Adding Value Grant web app. The framework used is Grafana k6.
 
-## Requirements
-- Docker
-- npm
-- k6 (if running outside a container)
+## Set up
+k6 can be installed and run locally on the machine, or a docker container with k6 is available. See https://grafana.com/docs/k6/latest/set-up/install-k6/
 
-## Running tests outside a container
+k6 does not use NodeJS but _npm install_ can be used to install the _@types/k6_ package to give VS Code Intellisense.
+
+## Running k6 in a container
+Todo..
+
+## Running k6 on the machine
 ```pwsh
-k6 run script.js
+# change root url as needed
+k6 run -e TEST_ENVIRONMENT_ROOT_URL=https://ffc-grants-frontend-test.azure.defra.cloud script.js
 ```

--- a/test/performance/docker-compose.yaml
+++ b/test/performance/docker-compose.yaml
@@ -1,0 +1,6 @@
+services:
+  perf-test:
+    build: .
+    image: perf-test
+    environment:
+      TEST_ENVIRONMENT_ROOT_URL: https://ffc-grants-frontend-test.azure.defra.cloud

--- a/test/performance/package-lock.json
+++ b/test/performance/package-lock.json
@@ -1,0 +1,23 @@
+{
+  "name": "performance",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "performance",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@types/k6": "^0.54.0"
+      }
+    },
+    "node_modules/@types/k6": {
+      "version": "0.54.1",
+      "resolved": "https://registry.npmjs.org/@types/k6/-/k6-0.54.1.tgz",
+      "integrity": "sha512-ezTMhuWr3TZIMOqAv51/4rD5T4FE1pSryrh5BCgxsniuqxbi5jQ3YEiOlO9C1+LvJcliC2byyd2Cw6cnUY7CLg==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/test/performance/package.json
+++ b/test/performance/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "script.js",
   "scripts": {
-    "test": "k6 run script.js"
+    "test": "k6 run -e TEST_ENVIRONMENT_ROOT_URL=https://ffc-grants-frontend-test.azure.defra.cloud script.js"
   },
   "keywords": [],
   "author": "",

--- a/test/performance/package.json
+++ b/test/performance/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "performance",
+  "version": "1.0.0",
+  "main": "script.js",
+  "scripts": {
+    "test": "k6 run script.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "devDependencies": {
+    "@types/k6": "^0.54.0"
+  }
+}

--- a/test/performance/package.json
+++ b/test/performance/package.json
@@ -8,7 +8,7 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "description": "",
+  "description": "Adding Value Performance Test",
   "devDependencies": {
     "@types/k6": "^0.54.0"
   }

--- a/test/performance/script.js
+++ b/test/performance/script.js
@@ -1,0 +1,115 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+export const options = {
+    vus: 50,
+    duration: '2m',
+    thresholds: {
+      http_req_failed: ['rate<0.01'], // http errors should be less than 1%
+      http_req_duration: ['p(95)<1500'], // 95% of requests should be below 1500ms
+    }
+};
+
+export default function () {
+    let response = null;
+    let crumb = null;
+
+    const submitJourneyForm = function(fields) {
+        sleep(2); // mimic human behaviour
+        let fieldsWithCrumb = { crumb: crumb };
+        if (fields) {
+            for (const [key, value] of Object.entries(fields)) {
+                fieldsWithCrumb[key] = value;
+            }
+        }
+        response = response.submitForm({ formSelector: `form[method='POST']`, fields: fieldsWithCrumb });
+        check(response, { 'is status 200': (r) => r.status === 200});
+    }
+
+    const followLinkWithText = function(text) {
+        response = response.clickLink({ selector: `a:contains('${text}')` });
+    }
+
+    response = http.get('https://ffc-grants-frontend-test.azure.defra.cloud/adding-value/start');
+
+    // start
+    if (response.url.endsWith('login')) {
+        response = response.submitForm({ fields: { username: 'grants', password: 'grants2021' }});
+    }
+    followLinkWithText('Start now');
+    crumb = response.html().find('#crumb').attr('value');
+
+    // nature-of-business
+    submitJourneyForm({ applicantBusiness: 'applicantBusiness' });
+    // legal-status
+    submitJourneyForm({ legalStatus: 'Sole trader' });    
+    // country
+    submitJourneyForm({ inEngland: 'Yes' });
+    // planning-permission
+    submitJourneyForm({ planningPermission: 'Secured' });
+    // project-start
+    submitJourneyForm({ projectStart: 'No, we have not done any work on this project yet'} );
+    // tenancy
+    submitJourneyForm({ tenancy: 'Yes'});
+    // smaller-abattoir
+    submitJourneyForm({ smallerAbattoir: 'Yes'});
+    // other-farmers
+    submitJourneyForm({ otherFarmers: 'Yes' });
+    // project-items
+    submitJourneyForm({ projectItems: 'Constructing or improving buildings for processing' });
+    // storage
+    submitJourneyForm({ storage: 'Yes, we will need storage facilities' });
+    // solar-PV-system
+    submitJourneyForm({ solarPVSystem: 'Yes' });
+    // project-cost
+    submitJourneyForm({ projectCost: '100000' });
+    // solar-PV-cost
+    submitJourneyForm({ solarPVCost: '50000' });
+    // potential-amount-solar
+    followLinkWithText('Continue');
+    // remaining-costs
+    submitJourneyForm({ canPayRemainingCost: 'Yes' });
+    // produce-processed
+    submitJourneyForm({ productsProcessed: 'Wild venison meat produce' });
+    // how-adding-value
+    submitJourneyForm({ howAddingValue: 'Introducing a new product to your farm' });
+    // project-impact
+    submitJourneyForm({ projectImpact: ['Increasing range of added-value products', 'Increasing volume of added-value products'] });
+    // mechanisation
+    submitJourneyForm({ mechanisation: 'Yes' });
+    // manual-labour-amount
+    submitJourneyForm({ manualLabour: 'More than 10%' });
+    // future-customers
+    submitJourneyForm({ futureCustomers: ['Processors', 'Wholesalers'] });
+    // collaboration
+    submitJourneyForm({ collaboration: 'Yes' });
+    // environmental-impact
+    submitJourneyForm({ environmentalImpact: ['Renewable energy', 'Energy efficiency'] });
+    // score
+    submitJourneyForm();
+    // business-details
+    submitJourneyForm({ projectName: 'Smaller Abattoir Project', businessName: 'Test Farm Ltd', numberEmployees: '5', businessTurnover: '2000000', sbi: '123456789' });
+    // applying
+    submitJourneyForm({ applying: 'Applicant' });
+    // applicant-details
+    submitJourneyForm({
+        firstName: 'James',
+        lastName: 'Test-Farmer',
+        emailAddress: 'cl-defra-tactical-grants-test-applicant-email@equalexperts.com',
+        confirmEmailAddress: 'cl-defra-tactical-grants-test-applicant-email@equalexperts.com',
+        mobileNumber: '07777 123456',
+        landlineNumber: '01604 123456',
+        address1: 'Test Farm',
+        address2: 'Cogenhoe',
+        town: 'Northampton',
+        county: 'Northamptonshire',
+        postcode: 'NN7 1NN',
+        projectPostcode: 'NN7 2NN'
+     });
+     // check-details
+     submitJourneyForm();
+     // confirm
+     submitJourneyForm();
+
+    console.warn("URL is: " + response.url);
+}

--- a/test/performance/script.js
+++ b/test/performance/script.js
@@ -11,33 +11,26 @@ export const options = {
 };
 
 export default function () {
-    let response = null;
-    let crumb = null;
-
     const submitJourneyForm = function(fields) {
-        sleep(2); // mimic human behaviour
-        let fieldsWithCrumb = { crumb: crumb };
-        if (fields) {
-            for (const [key, value] of Object.entries(fields)) {
-                fieldsWithCrumb[key] = value;
-            }
-        }
-        response = response.submitForm({ formSelector: `form[method='POST']`, fields: fieldsWithCrumb });
-        check(response, { 'is status 200': (r) => r.status === 200});
+        sleep(3); // mimic human behaviour
+        fields = fields ?? {};
+        fields['crumb'] = crumb;
+        response = response.submitForm({ formSelector: `form[method='POST']`, fields: fields });
+        check(response, { 'is http response status 200': (r) => r.status === 200 });
     }
 
     const followLinkWithText = function(text) {
         response = response.clickLink({ selector: `a:contains('${text}')` });
     }
 
-    response = http.get('https://ffc-grants-frontend-test.azure.defra.cloud/adding-value/start');
+    let response = http.get('https://ffc-grants-frontend-test.azure.defra.cloud/adding-value/start');
 
     // start
     if (response.url.endsWith('login')) {
         response = response.submitForm({ fields: { username: 'grants', password: 'grants2021' }});
     }
     followLinkWithText('Start now');
-    crumb = response.html().find('#crumb').attr('value');
+    let crumb = response.html().find('#crumb').attr('value');
 
     // nature-of-business
     submitJourneyForm({ applicantBusiness: 'applicantBusiness' });
@@ -110,6 +103,4 @@ export default function () {
      submitJourneyForm();
      // confirm
      submitJourneyForm();
-
-    console.warn("URL is: " + response.url);
 }

--- a/test/performance/script.js
+++ b/test/performance/script.js
@@ -1,5 +1,6 @@
 import http from 'k6/http';
-import { check, sleep } from 'k6';
+import { sleep } from 'k6';
+import { describe, expect } from 'https://jslib.k6.io/k6chaijs/4.3.4.3/index.js';
 
 export const options = {
     scenarios: {
@@ -11,7 +12,7 @@ export const options = {
                 { duration: '90s', target: 50 }
             ],
             gracefulRampDown: '0s',
-            gracefulStop: '0s'
+            gracefulStop: '60s'
         },
     },
     thresholds: {
@@ -20,104 +21,109 @@ export const options = {
 };
 
 export default function () {
-    const checkHttpStatusIs200 = function() {
-        check(response, { 'is status 200': (r) => r.status === 200 });
-    }
+    describe('Checker Journey', (t) => { performCheckerJourney() });
+}
 
+function performCheckerJourney () {
     const submitJourneyForm = function(fields) {
-        sleep(2); // mimic human interaction
+        sleep(3); // mimic human interaction
         fields = fields ?? {};
         let crumb = response.html().find(`input[name='crumb']`).attr('value');
         fields['crumb'] = crumb;
         response = response.submitForm({ formSelector: `form[method='POST']`, fields: fields });
-        checkHttpStatusIs200();
+        expect(response.status).to.equal(200);
     }
 
     const followLinkWithText = function(text) {
         response = response.clickLink({ selector: `a:contains('${text}')` });
-        checkHttpStatusIs200();
+        expect(response.status).to.equal(200);
     }
 
-    console.log(`Beginning journey for VU: ${__VU.toString().padStart(2, '0')}, ITER: ${__ITER}`);
+    let response = null;
 
-    let response = http.get(`${__ENV.TEST_ENVIRONMENT_ROOT_URL}/adding-value/start`);
-    checkHttpStatusIs200();
+    try {
+        response = http.get(`${__ENV.TEST_ENVIRONMENT_ROOT_URL}/adding-value/start`);
+        expect(response.status).to.equal(200);
 
-    // navigate past start page
-    if (response.url.endsWith('login')) {
-        submitJourneyForm({ username: 'grants', password: 'grants2021' });
+        // navigate past start page
+        if (response.url.endsWith('login')) {
+            submitJourneyForm({ username: 'grants', password: 'grants2021' });
+        }
+        followLinkWithText('Start now');
+
+        // nature-of-business
+        submitJourneyForm({ applicantBusiness: 'applicantBusiness' });
+        // legal-status
+        submitJourneyForm({ legalStatus: 'Sole trader' });    
+        // country
+        submitJourneyForm({ inEngland: 'Yes' });
+        // planning-permission
+        submitJourneyForm({ planningPermission: 'Secured' });
+        // project-start
+        submitJourneyForm({ projectStart: 'No, we have not done any work on this project yet'} );
+        // tenancy
+        submitJourneyForm({ tenancy: 'Yes'});
+        // smaller-abattoir
+        submitJourneyForm({ smallerAbattoir: 'Yes'});
+        // other-farmers
+        submitJourneyForm({ otherFarmers: 'Yes' });
+        // project-items
+        submitJourneyForm({ projectItems: 'Constructing or improving buildings for processing' });
+        // storage
+        submitJourneyForm({ storage: 'Yes, we will need storage facilities' });
+        // solar-PV-system
+        submitJourneyForm({ solarPVSystem: 'Yes' });
+        // project-cost
+        submitJourneyForm({ projectCost: '100000' });
+        // solar-PV-cost
+        submitJourneyForm({ solarPVCost: '50000' });
+        // potential-amount-solar
+        followLinkWithText('Continue');
+        // remaining-costs
+        submitJourneyForm({ canPayRemainingCost: 'Yes' });
+        // produce-processed
+        submitJourneyForm({ productsProcessed: 'Wild venison meat produce' });
+        // how-adding-value
+        submitJourneyForm({ howAddingValue: 'Introducing a new product to your farm' });
+        // project-impact
+        submitJourneyForm({ projectImpact: ['Increasing range of added-value products', 'Increasing volume of added-value products'] });
+        // mechanisation
+        submitJourneyForm({ mechanisation: 'Yes' });
+        // manual-labour-amount
+        submitJourneyForm({ manualLabour: 'More than 10%' });
+        // future-customers
+        submitJourneyForm({ futureCustomers: ['Processors', 'Wholesalers'] });
+        // collaboration
+        submitJourneyForm({ collaboration: 'Yes' });
+        // environmental-impact
+        submitJourneyForm({ environmentalImpact: ['Renewable energy', 'Energy efficiency'] });
+        // score
+        submitJourneyForm();
+        // business-details
+        submitJourneyForm({ projectName: 'Smaller Abattoir Project', businessName: 'Test Farm Ltd', numberEmployees: '5', businessTurnover: '2000000', sbi: '123456789' });
+        // applying
+        submitJourneyForm({ applying: 'Applicant' });
+        // applicant-details
+        submitJourneyForm({
+            firstName: 'James',
+            lastName: 'Test-Farmer',
+            emailAddress: 'cl-defra-tactical-grants-test-applicant-email@equalexperts.com',
+            confirmEmailAddress: 'cl-defra-tactical-grants-test-applicant-email@equalexperts.com',
+            mobileNumber: '07777 123456',
+            landlineNumber: '01604 123456',
+            address1: 'Test Farm',
+            address2: 'Cogenhoe',
+            town: 'Northampton',
+            county: 'Northamptonshire',
+            postcode: 'NN7 1NN',
+            projectPostcode: 'NN7 2NN'
+        });
+        // check-details
+        submitJourneyForm();
+        // confirm
+        //submitJourneyForm(); # avoid generating emails in pre
+    } catch (error) {
+        console.error(`Error for URL: ${response?.url}, body: ${response.body.substring(0, 200)}`);
+        throw error;
     }
-    followLinkWithText('Start now');
-
-    // nature-of-business
-    submitJourneyForm({ applicantBusiness: 'applicantBusiness' });
-    // legal-status
-    submitJourneyForm({ legalStatus: 'Sole trader' });    
-    // country
-    submitJourneyForm({ inEngland: 'Yes' });
-    // planning-permission
-    submitJourneyForm({ planningPermission: 'Secured' });
-    // project-start
-    submitJourneyForm({ projectStart: 'No, we have not done any work on this project yet'} );
-    // tenancy
-    submitJourneyForm({ tenancy: 'Yes'});
-    // smaller-abattoir
-    submitJourneyForm({ smallerAbattoir: 'Yes'});
-    // other-farmers
-    submitJourneyForm({ otherFarmers: 'Yes' });
-    // project-items
-    submitJourneyForm({ projectItems: 'Constructing or improving buildings for processing' });
-    // storage
-    submitJourneyForm({ storage: 'Yes, we will need storage facilities' });
-    // solar-PV-system
-    submitJourneyForm({ solarPVSystem: 'Yes' });
-    // project-cost
-    submitJourneyForm({ projectCost: '100000' });
-    // solar-PV-cost
-    submitJourneyForm({ solarPVCost: '50000' });
-    // potential-amount-solar
-    followLinkWithText('Continue');
-    // remaining-costs
-    submitJourneyForm({ canPayRemainingCost: 'Yes' });
-    // produce-processed
-    submitJourneyForm({ productsProcessed: 'Wild venison meat produce' });
-    // how-adding-value
-    submitJourneyForm({ howAddingValue: 'Introducing a new product to your farm' });
-    // project-impact
-    submitJourneyForm({ projectImpact: ['Increasing range of added-value products', 'Increasing volume of added-value products'] });
-    // mechanisation
-    submitJourneyForm({ mechanisation: 'Yes' });
-    // manual-labour-amount
-    submitJourneyForm({ manualLabour: 'More than 10%' });
-    // future-customers
-    submitJourneyForm({ futureCustomers: ['Processors', 'Wholesalers'] });
-    // collaboration
-    submitJourneyForm({ collaboration: 'Yes' });
-    // environmental-impact
-    submitJourneyForm({ environmentalImpact: ['Renewable energy', 'Energy efficiency'] });
-    // score
-    submitJourneyForm();
-    // business-details
-    submitJourneyForm({ projectName: 'Smaller Abattoir Project', businessName: 'Test Farm Ltd', numberEmployees: '5', businessTurnover: '2000000', sbi: '123456789' });
-    // applying
-    submitJourneyForm({ applying: 'Applicant' });
-    // applicant-details
-    submitJourneyForm({
-        firstName: 'James',
-        lastName: 'Test-Farmer',
-        emailAddress: 'cl-defra-tactical-grants-test-applicant-email@equalexperts.com',
-        confirmEmailAddress: 'cl-defra-tactical-grants-test-applicant-email@equalexperts.com',
-        mobileNumber: '07777 123456',
-        landlineNumber: '01604 123456',
-        address1: 'Test Farm',
-        address2: 'Cogenhoe',
-        town: 'Northampton',
-        county: 'Northamptonshire',
-        postcode: 'NN7 1NN',
-        projectPostcode: 'NN7 2NN'
-     });
-     // check-details
-     submitJourneyForm();
-     // confirm and generate spreadsheet
-     submitJourneyForm();
 }

--- a/test/performance/script.js
+++ b/test/performance/script.js
@@ -23,7 +23,7 @@ export default function () {
         response = response.clickLink({ selector: `a:contains('${text}')` });
     }
 
-    let response = http.get('https://ffc-grants-frontend-test.azure.defra.cloud/adding-value/start');
+    let response = http.get(`${__ENV.TEST_ENVIRONMENT_ROOT_URL}/adding-value/start`);
 
     // start
     if (response.url.endsWith('login')) {

--- a/test/performance/script.js
+++ b/test/performance/script.js
@@ -101,6 +101,6 @@ export default function () {
      });
      // check-details
      submitJourneyForm();
-     // confirm
+     // confirm and generate spreadsheet
      submitJourneyForm();
 }

--- a/test/performance/script.js
+++ b/test/performance/script.js
@@ -2,8 +2,8 @@ import http from 'k6/http';
 import { check, sleep } from 'k6';
 
 export const options = {
-    vus: 50,
-    duration: '2m',
+    vus: 50, // 50 virtual users
+    duration: '2m', // run default function for 2 mins
     thresholds: {
       http_req_failed: ['rate<0.01'], // http errors should be less than 1%
       http_req_duration: ['p(95)<1500'], // 95% of requests should be below 1500ms
@@ -16,7 +16,7 @@ export default function () {
         fields = fields ?? {};
         fields['crumb'] = crumb;
         response = response.submitForm({ formSelector: `form[method='POST']`, fields: fields });
-        check(response, { 'is http response status 200': (r) => r.status === 200 });
+        check(response, { 'is http response status 200': (r) => r.status === 200 }); // build a check of response status codes
     }
 
     const followLinkWithText = function(text) {
@@ -25,7 +25,7 @@ export default function () {
 
     let response = http.get(`${__ENV.TEST_ENVIRONMENT_ROOT_URL}/adding-value/start`);
 
-    // start
+    // start page
     if (response.url.endsWith('login')) {
         response = response.submitForm({ fields: { username: 'grants', password: 'grants2021' }});
     }


### PR DESCRIPTION
This pull request shows a performance test written for 'Adding Value Round 2', a typical Grant Eligibility Checker, using Grafana k6. The NFR being tested is 50 concurrent users interacting with the 30 page journey over a 2 minute period with a 30 second ramp up. All responses should be successful and 95% should be within 1500 milliseconds. This test uses direct HTTP interactions to mimic the GETs and POSTs of the web application. A browser-based k6 test could also be written if it was felt the web application did an appreciable amount of processing in client-side code that could affect performance.

The prevalent Defra performance testing tool is Apache JMeter. We would prefer not to use JMeter for a number of reasons:
- Configured via GUI
- Large XML files in source control
- PRs difficult to review 
- Java-based
- Slightly dated approach overall

Our preferred tool is k6 for the following reasons:
- Modern code-first approach
- JavaScript, lives in application repository alongside other tests
- Docker image for pipeline use
- Support for both HTTP and browser execution
- Free to use, open source
- Actively maintained project